### PR TITLE
fix: videojs-contrib-quality-levels

### DIFF
--- a/docs/player.html
+++ b/docs/player.html
@@ -526,7 +526,7 @@ player.source(source1);</code></pre>
 	</div>
 	<script type="text/javascript" src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
 	<script type="text/javascript" src="https://unpkg.com/cloudinary-video-player/dist/cld-video-player.min.js"></script>
-	<script type="text/javascript" src="https://unpkg.com/videojs-contrib-quality-levels@2.0.3/dist/videojs-contrib-quality-levels.min.js"></script>
+	<script type="text/javascript" src="https://unpkg.com/videojs-contrib-quality-levels@4/dist/videojs-contrib-quality-levels.min.js"></script>
 	<script type="text/javascript" src="js/prism.js"></script>
 	<script type="text/javascript" src="js/main.js"></script>
 


### PR DESCRIPTION
Upgrading to videojs 8 caused `videojs-contrib-quality-levels@2.0.3` to stop working, this PR upgrades it to 4.x, fix confirmed locally.